### PR TITLE
Bug Fixes & Cleanup. 

### DIFF
--- a/app/src/main/java/com/example/nova/MainActivity.kt
+++ b/app/src/main/java/com/example/nova/MainActivity.kt
@@ -120,7 +120,7 @@ class MainActivity : ComponentActivity() {
                                                 )
                                             }
                                             Button(onClick = {
-                                                viewModel.fetchWeatherForCity("Minnetrista,MN,US")
+                                                viewModel.resetToDefaultLocation() //when theres an error, reset to the default location
                                             },
                                                 shape = MaterialTheme.shapes.small,
                                                 colors = ButtonDefaults.buttonColors(
@@ -130,7 +130,7 @@ class MainActivity : ComponentActivity() {
                                                 modifier = Modifier.padding(16.dp)
                                                 ) {
                                                 Text(
-                                                    "Retry",
+                                                    stringResource(R.string.reset_location),
                                                     fontFamily = MochiPopOne
                                                 )
                                             }

--- a/app/src/main/java/com/example/nova/ui/screens/CurrentWeatherScreen.kt
+++ b/app/src/main/java/com/example/nova/ui/screens/CurrentWeatherScreen.kt
@@ -258,6 +258,29 @@ fun CurrentWeatherScreen(
                     )
                 }
             }
+
+            //spacer for second row
+            Spacer(modifier = Modifier.height(8.dp))
+
+            //in second row
+            //adding button to reset to the default location
+            Button(
+                onClick = {
+                    viewModel.resetToDefaultLocation()
+                    zipCode = "" //clear zip
+                    isZipCodeError = false
+                },
+                shape = MaterialTheme.shapes.small,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Brown,
+                    contentColor = White
+                ),
+            ) {
+                Text(
+                    stringResource(R.string.reset_location),
+                    fontFamily = MochiPopOne
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/nova/ui/screens/ForecastScreen.kt
+++ b/app/src/main/java/com/example/nova/ui/screens/ForecastScreen.kt
@@ -45,7 +45,9 @@ fun ForecastScreen(
         //back button at the top -> only display if error is not thrown
         if (error == null) {
             Button(
-                onClick = { navController.navigateUp() },
+                onClick = {
+                    navController.navigateUp()
+                },
                 shape = MaterialTheme.shapes.small,
                 colors = ButtonDefaults.buttonColors(
                     containerColor = Brown,
@@ -90,7 +92,6 @@ fun ForecastScreen(
                                 modifier = Modifier.padding(16.dp)
                             )
                             //'Back to Current Weather' for invalid zip/error
-                            //'Back to Current Weather' button for valid zip
                             Button(
                                 onClick = {
                                     navController.navigateUp()

--- a/app/src/main/java/com/example/nova/ui/viewmodel/WeatherViewModel.kt
+++ b/app/src/main/java/com/example/nova/ui/viewmodel/WeatherViewModel.kt
@@ -78,10 +78,18 @@ class WeatherViewModel(
         fetchWeatherForLocation(city, LocationType.CITY)
     }
 
-    //these two functions I left in because they were mentioned, I wanted to wait and see whether or I'd need them.
+    //fetch weather for a zipcode
     fun fetchWeatherForZipCode(zipCode: String) {
         fetchWeatherForLocation(zipCode, LocationType.ZIP_CODE)
     }
+
+    //function to reset to default location
+    fun resetToDefaultLocation() {
+        _error.value = null //clear previous errors
+        fetchWeatherForCity(DEFAULT_LOCATION)
+    }
+
+
 
     //this is the main method to fetch weather data for any location type.
     //handles loading state, caching, error handling, and rate limiting.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
     <string name="no_forecast_data">No forecast data available</string>
     <string name="humidity_with_value">Humidity: %1$d%%</string>
     <string name="wind_speed">Wind: %1$.1f mph</string>
+    <string name="reset_location">Reset Location</string>
 </resources>


### PR DESCRIPTION
WeatherViewModel:
-added function to reset weather to default zip incase of error with grabbing zip in WeatherViewModel -clarified on old comments.

CurrentWeatherScreen:
-added a button to reset the location easily to the default, always shown on CurrentWeatherScreen. -Matched styling of other buttons.

strings.xml:
-externalized a "reset_location" string to show on the button.

MainActivity:
-changed 'retry' button to reset location on error, seems to be a better way of handling errors. It calls the previously stated function in WeatherViewModel. -Removed non-externalized string 'Retry', replaced with the externalized reset_location string. Effectively does what 'Retry' was supposed to.

ForecastScreen:
-Removed duplicate comment.
-Fixed Formatting on a couple lines.